### PR TITLE
Removes duplicate files from Super Nintendo cheats.

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/cheats/cht/Super Nintendo/Pro Action Replay/Aero the AcroBat.cht
+++ b/board/recalbox/fsoverlay/recalbox/share_init/cheats/cht/Super Nintendo/Pro Action Replay/Aero the AcroBat.cht
@@ -1,6 +1,0 @@
-cheats = 1 
-
-cheat0_desc = "Infinite Time"
-cheat0_code = "7E0CC059+7E0CC102"
-cheat0_enable = false 
-

--- a/board/recalbox/fsoverlay/recalbox/share_init/cheats/cht/Super Nintendo/Pro Action Replay/Al Unser Jrs Road to the Top.cht
+++ b/board/recalbox/fsoverlay/recalbox/share_init/cheats/cht/Super Nintendo/Pro Action Replay/Al Unser Jrs Road to the Top.cht
@@ -1,6 +1,0 @@
-cheats = 1 
-
-cheat0_desc = "Speed Modifier"
-cheat0_code = "7E05A8??"
-cheat0_enable = false 
-


### PR DESCRIPTION
These two files have duplicates with the same file names (except letter case). This clashes when pulling the sources in Windows.