### PR TITLE
Fix compiling kodi on raspberry pi

### DIFF
--- a/package/kodi/0004-CMAKE-Add-armv7l-to-script.patch
+++ b/package/kodi/0004-CMAKE-Add-armv7l-to-script.patch
@@ -1,0 +1,13 @@
+diff -Naur kodi-17.3-Krypton/project/cmake/scripts/rbpi/ArchSetup.cmake kodi-17.3-Krypton.patch/project/cmake/scripts/rbpi/ArchSetup.cmake
+
+--- kodi-17.3-Krypton/project/cmake/scripts/rbpi/ArchSetup.cmake	2017-09-18 18:55:19.710539708 +0200
++++ kodi-17.3-Krypton.patch/project/cmake/scripts/rbpi/ArchSetup.cmake	2017-09-18 18:54:57.230689124 +0200
+@@ -14,7 +14,7 @@
+     set(ARCH arm)
+     set(NEON False)
+     set(NEON_FLAGS "-mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp")
+-  elseif(CPU MATCHES "cortex-a7" OR CPU MATCHES "cortex-a53")
++  elseif(CPU MATCHES "cortex-a7" OR CPU MATCHES "armv7l" OR CPU MATCHES "cortex-a53")
+     set(ARCH arm)
+     set(NEON True)
+     set(NEON_FLAGS "-fPIC -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad")


### PR DESCRIPTION
Compiling on RPI3, is not possible due to missing armv7l ???

Or missing cortex-a8 in kodi https://github.com/xbmc/xbmc/blob/Krypton/project/cmake/scripts/rbpi/ArchSetup.cmake#L13

FIxed by patching this script.

diff -Naur kodi-17.3-Krypton/project/cmake/scripts/rbpi/ArchSetup.cmake kodi-17.3-Krypton.patch/project/cmake/scripts/rbpi/ArchSetup.cmake

--- kodi-17.3-Krypton/project/cmake/scripts/rbpi/ArchSetup.cmake	2017-09-18 18:55:19.710539708 +0200
+++ kodi-17.3-Krypton.patch/project/cmake/scripts/rbpi/ArchSetup.cmake	2017-09-18 18:54:57.230689124 +0200
@@ -14,7 +14,7 @@
     set(ARCH arm)
     set(NEON False)
     set(NEON_FLAGS "-mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp")
-  elseif(CPU MATCHES "cortex-a7" OR CPU MATCHES "cortex-a53")
+  elseif(CPU MATCHES "cortex-a7" OR CPU MATCHES "armv7l" OR CPU MATCHES "cortex-a53")
     set(ARCH arm)
     set(NEON True)
     set(NEON_FLAGS "-fPIC -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad")