### PR TITLE
Splash Screen sound fixed for 3.5mm jack output

### DIFF
--- a/board/recalbox/fsoverlay/etc/init.d/S02splash
+++ b/board/recalbox/fsoverlay/etc/init.d/S02splash
@@ -26,7 +26,7 @@ do_start ()
         omx_fnt=""
         omx_opt="--no-keys --layer=10000 --aspect-mode=fill"
         omx_srt="--no-ghost-box --lines=1 --align=left $omx_fnt --font-size=20 --subtitles=/recalbox/system/resources/splash/recalboxintro.srt"
-        /usr/bin/omxplayer $omx_opt $omx_srt $video &
+        /usr/bin/omxplayer -o both $omx_opt $omx_srt $video &
         PID=$!
 
         # Stop the video when ready


### PR DESCRIPTION
Force output over both the 3.5mm jack and HDMI 

-Genetik57