### PR TITLE
Added missing R2, (RT),  button for Microsoft X-Box 360 pad

### DIFF
--- a/board/recalbox/fsoverlay/recalbox/share_init/system/.emulationstation/es_input.cfg
+++ b/board/recalbox/fsoverlay/recalbox/share_init/system/.emulationstation/es_input.cfg
@@ -195,6 +195,7 @@
         <input name="left" type="hat" id="0" value="8" code="16" />
         <input name="pagedown" type="button" id="5" value="1" code="311" />
         <input name="pageup" type="button" id="4" value="1" code="310" />
+        <input name="r2" type="axis" id="5" value="1" code="5" />
         <input name="r3" type="button" id="10" value="1" code="318" />
         <input name="right" type="hat" id="0" value="2" code="16" />
         <input name="select" type="button" id="6" value="1" code="314" />


### PR DESCRIPTION
The default configuration for the R2 button is missing for the Microsoft X-Box 360 pad